### PR TITLE
Update Prisma client output directory

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../../node_modules/@prisma/client"
+  output   = "../../node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
Changed the Prisma client generator output path from '@prisma/client' to '.prisma/client' to align with updated directory structure or tooling requirements.