### PR TITLE
Update Vite base path to root

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-    base: './',
+    base: '/',
     build: {
         outDir: 'dist',
         assetsDir: 'assets',


### PR DESCRIPTION
Changed the Vite config 'base' option from './' to '/' to ensure assets and routing work correctly when deploying to the server root.